### PR TITLE
Separate column test cases

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -27,3 +27,8 @@ Cypress.Commands.add('assertTestIdOrder', (selector, values) => {
       .should('eq', childSelector);
   });
 });
+
+Cypress.Commands.add('step', (name, callback) => {
+  cy.log(name);
+  callback();
+});


### PR DESCRIPTION
Previously the columns test suite had a single test that went sequentially through a series of steps. This approach can help with E2E test performance.

But in this case it doesn't save a lot of performance as there's not much setup, it doesn't help build up state because we mock out the backend, and it can make tests harder for newcomers to understand and slow down the TDD process.

This PR attempts to address these issues by:

- Splitting the large test with steps into separate tests
- Extracting shared setup
- Creating a `cy.step()` command that makes it easy to describe a series of low-level commands in human language, automatically logging it out in the test runner

Instead of looking at the diff, it may be easiest to review by looking at [the final test file](https://github.com/CodingItWrong/listapp-expo/blob/separate-test-cases/cypress/e2e/edit-columns.cy.js#L76)

Rather than update the other tests in this PR, I may wait to update them as I touch the relevant functionality.