### PR TITLE
Restore uuid functionality on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "@tanstack/react-query": "^4.24.9",
     "dayjs": "^1.11.7",
     "expo": "^48.0.0",
-    "expo-crypto": "~12.2.1",
     "expo-dev-client": "~2.1.3",
+    "expo-random": "~13.1.1",
     "expo-secure-store": "~12.1.1",
     "expo-splash-screen": "~0.18.1",
     "expo-standard-web-crypto": "^1.4.1",
@@ -54,9 +54,9 @@
     "eslint": "^8.34",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-import": "^2.27.5",
+    "husky": "^8.0.0",
     "prettier": "^2.8.4",
-    "typescript": "^4.9.5",
-    "husky": "^8.0.0"
+    "typescript": "^4.9.5"
   },
   "private": true
 }

--- a/src/utils/uuid.js
+++ b/src/utils/uuid.js
@@ -1,4 +1,7 @@
+import {polyfillWebCrypto} from 'expo-standard-web-crypto';
+polyfillWebCrypto();
 import {v4 as uuidv4} from 'uuid';
 
-// in a module as previously polyfilling was required
+// Mobile says "Random.getRandomBytes is not supported; falling back to insecure Math.random"
+// But this is fine for this use case
 export default uuidv4;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4877,13 +4877,6 @@ expo-constants@~14.2.0, expo-constants@~14.2.1:
     "@expo/config" "~8.0.0"
     uuid "^3.3.2"
 
-expo-crypto@~12.2.1:
-  version "12.2.1"
-  resolved "https://registry.yarnpkg.com/expo-crypto/-/expo-crypto-12.2.1.tgz#d4f0ef5e2148e1168628d0ebcc2697da3e5df8b3"
-  integrity sha512-NfKsREzj55xCm0v9OKuNw3DU1r6i6VNTYrQcYSZfGOp7o+tvZsJRyr+NyrUg5YVH93TUkothCtsPahdYA4r1Wg==
-  dependencies:
-    base64-js "^1.3.0"
-
 expo-dev-client@~2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/expo-dev-client/-/expo-dev-client-2.1.3.tgz#4f8f69fdb65124c6a1d4629a092d8127f5cb5c05"
@@ -4981,6 +4974,13 @@ expo-pwa@0.0.124:
     chalk "^4.0.0"
     commander "2.20.0"
     update-check "1.5.3"
+
+expo-random@~13.1.1:
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/expo-random/-/expo-random-13.1.1.tgz#15e781911d5db4fbcee75e26ac109bc2523fe00c"
+  integrity sha512-+KkhGp7xW45GvMRzlcSOzvDwzTgyXo6C84GaG4GI43rOdECBQ2lGUJ12st39OtfZm1lORNskpi66DjnuJ73g9w==
+  dependencies:
+    base64-js "^1.3.0"
 
 expo-secure-store@~12.1.1:
   version "12.1.1"


### PR DESCRIPTION
Restores `expo-random` for now so can use the same native build.

After that, will work on replacing it with `expo-crypto` next.