### PR TITLE
Action closes card

### DIFF
--- a/cypress/e2e/buttons.cy.js
+++ b/cypress/e2e/buttons.cy.js
@@ -121,7 +121,6 @@ describe('buttons', () => {
     });
 
     cy.get(`[data-testid=button-${releaseButton.id}]`).click();
-    cy.get('[aria-label="Close card"]').click();
 
     cy.get(`[data-testid="column-${releasedColumn.id}"]`).contains(title);
   });

--- a/cypress/e2e/edit-buttons.cy.js
+++ b/cypress/e2e/edit-buttons.cy.js
@@ -156,7 +156,6 @@ describe('edit buttons', () => {
     });
 
     cy.step('CONFIRM INFO CLEARED IN LIST', () => {
-      cy.get('[aria-label="Close card"]').click();
       cy.contains(greetingText).should('not.exist');
     });
   });
@@ -378,7 +377,6 @@ describe('edit buttons', () => {
     });
 
     cy.step('CONFIRM FIELD DATA UPDATED ON CARD', () => {
-      cy.get('[aria-label="Close card"]').click();
       cy.contains('Thu Jan 3, 2999');
     });
   });
@@ -521,7 +519,6 @@ describe('edit buttons', () => {
         .should('deep.equal', {data: uncompletedCard});
 
       // wait to go back to card list
-      cy.get('[aria-label="Close card"]').click();
       cy.contains(menuName).should('not.exist');
 
       // wait for card list to reload

--- a/src/screens/Card/EditCardForm.js
+++ b/src/screens/Card/EditCardForm.js
@@ -50,8 +50,7 @@ export default function EditCardForm({card, board, onClose}) {
           const concreteValue = valueObject.call(
             fieldObject.attributes['data-type'],
           );
-          setFieldValue(field, concreteValue);
-          handleUpdateCard({[field]: concreteValue});
+          handleUpdateCard({[field]: concreteValue}, {onSuccess: onClose});
         } else {
           console.error(`unknown value: ${value}`);
           return;
@@ -71,8 +70,7 @@ export default function EditCardForm({card, board, onClose}) {
         const startDate = getStartDate();
         const updatedDate = dateUtils.addDays(startDate, Number(value));
         const concreteValue = dateUtils.objectToServerString(updatedDate);
-        setFieldValue(field, concreteValue);
-        handleUpdateCard({[field]: concreteValue});
+        handleUpdateCard({[field]: concreteValue}, {onSuccess: onClose});
         break;
       default:
         console.error(`unknown command: ${command}`);
@@ -90,9 +88,9 @@ export default function EditCardForm({card, board, onClose}) {
     card,
     board,
   );
-  const handleUpdateCard = fieldOverrides => {
+  const handleUpdateCard = (fieldOverrides, options) => {
     const fieldValuesToUse = {...fieldValues, ...fieldOverrides};
-    return updateCard({'field-values': fieldValuesToUse});
+    updateCard({'field-values': fieldValuesToUse}, options);
   };
 
   function getErrorMessage() {


### PR DESCRIPTION
Ultimately we probably want this to be configurable (or scriptable), but until then, closing the card is my preferred default.