### PR TITLE
Code splitting

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,7 +1,5 @@
 import {CssBaseline} from '@mui/material';
 import {ThemeProvider as MuiProvider} from '@mui/material/styles';
-import {AdapterDayjs} from '@mui/x-date-pickers/AdapterDayjs';
-import {LocalizationProvider as DateLocalizationProvider} from '@mui/x-date-pickers/LocalizationProvider';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {ReactQueryDevtools} from '@tanstack/react-query-devtools';
 import Navigation from './src/Navigation';
@@ -26,12 +24,10 @@ export default function App() {
       <TokenLoadBuffer>
         <MuiProvider theme={theme}>
           <CssBaseline />
-          <DateLocalizationProvider dateAdapter={AdapterDayjs}>
-            <QueryClientProvider client={queryClient}>
-              {__DEV__ && <ReactQueryDevtools initialIsOpen={false} />}
-              <Navigation />
-            </QueryClientProvider>
-          </DateLocalizationProvider>
+          <QueryClientProvider client={queryClient}>
+            {__DEV__ && <ReactQueryDevtools initialIsOpen={false} />}
+            <Navigation />
+          </QueryClientProvider>
         </MuiProvider>
       </TokenLoadBuffer>
     </TokenProvider>

--- a/src/components/fieldTypes/date.js
+++ b/src/components/fieldTypes/date.js
@@ -1,7 +1,10 @@
-import {DatePicker} from '@mui/x-date-pickers/DatePicker';
-import dayjs from 'dayjs';
+import {Suspense, lazy} from 'react';
 import FIELD_DATA_TYPES from '../../enums/fieldDataTypes';
 import dateUtils from '../../utils/dateUtils';
+
+const LazyDateEditorComponent = lazy(() =>
+  import('./lazy/DateEditorComponent'),
+);
 
 const dateFieldDataType = {
   key: FIELD_DATA_TYPES.DATE.key,
@@ -13,26 +16,11 @@ const dateFieldDataType = {
   EditorComponent: DateEditorComponent,
 };
 
-function DateEditorComponent({field, label, value, setValue, disabled, style}) {
+function DateEditorComponent(props) {
   return (
-    <DatePicker
-      label={label}
-      value={value ? dayjs(value) : null}
-      onChange={dayJsObject => {
-        const string = dateUtils.objectToServerString(dayJsObject);
-        setValue(string);
-      }}
-      disabled={disabled}
-      slotProps={{
-        textField: {
-          variant: 'filled',
-          style,
-          inputProps: {
-            'data-testid': `date-input-${field.id}`,
-          },
-        },
-      }}
-    />
+    <Suspense fallback={<div>Loading…</div>}>
+      <LazyDateEditorComponent {...props} />
+    </Suspense>
   );
 }
 

--- a/src/components/fieldTypes/dateTime.js
+++ b/src/components/fieldTypes/dateTime.js
@@ -1,7 +1,10 @@
-import {DateTimePicker} from '@mui/x-date-pickers/DateTimePicker';
-import dayjs from 'dayjs';
+import {Suspense, lazy} from 'react';
 import FIELD_DATA_TYPES from '../../enums/fieldDataTypes';
 import dateTimeUtils from '../../utils/dateTimeUtils';
+
+const LazyDateEditorComponent = lazy(() =>
+  import('./lazy/DateEditorComponent'),
+);
 
 const dateTimeFieldDataType = {
   key: FIELD_DATA_TYPES.DATETIME.key,
@@ -13,31 +16,11 @@ const dateTimeFieldDataType = {
   EditorComponent: DateTimeEditorComponent,
 };
 
-function DateTimeEditorComponent({
-  field,
-  label,
-  value,
-  setValue,
-  style,
-  disabled,
-}) {
+function DateTimeEditorComponent(props) {
   return (
-    <DateTimePicker
-      label={label}
-      value={value ? dayjs(value) : null}
-      onChange={dayJsObject => {
-        const string = dateTimeUtils.objectToServerString(dayJsObject);
-        setValue(string);
-      }}
-      disabled={disabled}
-      slotProps={{
-        textField: {
-          style,
-          variant: 'filled',
-          'data-testid': `datetime-input-${field.id}`,
-        },
-      }}
-    />
+    <Suspense fallback={<div>Loading…</div>}>
+      <LazyDateEditorComponent {...props} />
+    </Suspense>
   );
 }
 

--- a/src/components/fieldTypes/geolocation.js
+++ b/src/components/fieldTypes/geolocation.js
@@ -1,12 +1,14 @@
-import {useState} from 'react';
+import {Suspense, lazy, useState} from 'react';
 import FIELD_DATA_TYPES from '../../enums/fieldDataTypes';
 import IconButton from '../IconButton';
 import LoadingIndicator from '../LoadingIndicator';
-import Map from '../Map';
 import NumberField from '../NumberField';
 import Stack from '../Stack';
 import Text from '../Text';
 import sharedStyles from '../sharedStyles';
+
+// lazy to defer loading google-maps-react
+const Map = lazy(() => import('../Map'));
 
 const geolocationFieldDataType = {
   key: FIELD_DATA_TYPES.GEOLOCATION.key,
@@ -93,12 +95,14 @@ function GeolocationEditorComponent({field, label, value, setValue, disabled}) {
           style={styles.grow}
         />
       </Stack>
-      <Map
-        location={value}
-        onPressLocation={handlePressLocation}
-        style={{...styles.detailMap, ...sharedStyles.mt}}
-        disabled={disabled}
-      />
+      <Suspense fallback={<div>Loading…</div>}>
+        <Map
+          location={value}
+          onPressLocation={handlePressLocation}
+          style={{...styles.detailMap, ...sharedStyles.mt}}
+          disabled={disabled}
+        />
+      </Suspense>
     </div>
   );
 }

--- a/src/components/fieldTypes/lazy/DateEditorComponent.js
+++ b/src/components/fieldTypes/lazy/DateEditorComponent.js
@@ -1,0 +1,32 @@
+import {DatePicker} from '@mui/x-date-pickers';
+import {AdapterDayjs} from '@mui/x-date-pickers/AdapterDayjs';
+import {LocalizationProvider as DateLocalizationProvider} from '@mui/x-date-pickers/LocalizationProvider';
+import dayjs from 'dayjs';
+import dateUtils from '../../../utils/dateUtils';
+
+function DateEditorComponent({field, label, value, setValue, disabled, style}) {
+  return (
+    <DateLocalizationProvider dateAdapter={AdapterDayjs}>
+      <DatePicker
+        label={label}
+        value={value ? dayjs(value) : null}
+        onChange={dayJsObject => {
+          const string = dateUtils.objectToServerString(dayJsObject);
+          setValue(string);
+        }}
+        disabled={disabled}
+        slotProps={{
+          textField: {
+            variant: 'filled',
+            style,
+            inputProps: {
+              'data-testid': `date-input-${field.id}`,
+            },
+          },
+        }}
+      />
+    </DateLocalizationProvider>
+  );
+}
+
+export default DateEditorComponent;

--- a/src/components/fieldTypes/lazy/DateTimeEditorComponent.js
+++ b/src/components/fieldTypes/lazy/DateTimeEditorComponent.js
@@ -1,0 +1,38 @@
+import {AdapterDayjs} from '@mui/x-date-pickers/AdapterDayjs';
+import {LocalizationProvider as DateLocalizationProvider} from '@mui/x-date-pickers/LocalizationProvider';
+import dayjs from 'dayjs';
+import dateTimeUtils from '../../utils/dateTimeUtils';
+
+const DateTimePicker = () => null;
+
+function DateTimeEditorComponent({
+  field,
+  label,
+  value,
+  setValue,
+  style,
+  disabled,
+}) {
+  return (
+    <DateLocalizationProvider dateAdapter={AdapterDayjs}>
+      <DateTimePicker
+        label={label}
+        value={value ? dayjs(value) : null}
+        onChange={dayJsObject => {
+          const string = dateTimeUtils.objectToServerString(dayJsObject);
+          setValue(string);
+        }}
+        disabled={disabled}
+        slotProps={{
+          textField: {
+            style,
+            variant: 'filled',
+            'data-testid': `datetime-input-${field.id}`,
+          },
+        }}
+      />
+    </DateLocalizationProvider>
+  );
+}
+
+export default DateTimeEditorComponent;

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -47,8 +47,13 @@ module.exports = {
     runtimeChunk: 'single',
     splitChunks: {
       cacheGroups: {
+        googleMaps: {
+          test: /[\\/]node_modules[\\/]google-maps-react/,
+          name: 'google-maps',
+          chunks: 'all',
+        },
         vendor: {
-          test: /[\\/]node_modules[\\/]/,
+          test: /[\\/]node_modules[\\/](?!google-maps-react)/,
           name: 'vendors',
           chunks: 'all',
         },

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -47,13 +47,18 @@ module.exports = {
     runtimeChunk: 'single',
     splitChunks: {
       cacheGroups: {
+        datePickers: {
+          test: /[\\/]node_modules[\\/]@mui[\\/]x-date-pickers/,
+          name: 'date-pickers',
+          chunks: 'all',
+        },
         googleMaps: {
           test: /[\\/]node_modules[\\/]google-maps-react/,
           name: 'google-maps',
           chunks: 'all',
         },
         vendor: {
-          test: /[\\/]node_modules[\\/](?!google-maps-react)/,
+          test: /[\\/]node_modules[\\/](?!google-maps-react|@mui[\\/]x-date-pickers)/,
           name: 'vendors',
           chunks: 'all',
         },


### PR DESCRIPTION
Splits out two significant chunks of vendor code that aren't always used: MUI X Date Pickers and Google Maps. They are loaded only when showing a field that uses them.

This reduces the size of the `vendors` bundle that's loaded on app load from 1 MB to 813 KB uncompressed. (Compressed will be significantly less on both counts.)

The other parts of the `vendors` bundle all seem to be necessary for almost all uses of the app, so code splitting doesn't make sense.