### PR TITLE
Fix issue where a column that is not full height might scroll

### DIFF
--- a/src/screens/Board/Column/Column.js
+++ b/src/screens/Board/Column/Column.js
@@ -94,7 +94,7 @@ export default function Column({column, board}) {
         sections={cardGroups}
         sectionKeyExtractor={group => group.value}
         itemKeyExtractor={card => card.id}
-        contentContainerStyle={sharedStyles.columnPadding}
+        contentContainerStyle={{...sharedStyles.columnPadding, flex: 1}}
         ListEmptyComponent={<Text size={3}>(no cards)</Text>}
         renderSectionHeader={({section: group}) => {
           if (!applyGrouping) {


### PR DESCRIPTION
Typically a column of cards would show no scrollbar until they were too high for the browser window, at which point they would gain a vertical scrollbar.

Sometimes, though, even if a column of cards fit on the screen, its container would not be quite high enough for all the cards, and a scrollbar would show:

![image](https://github.com/CodingItWrong/riverbed-web/assets/15832198/b2d805d8-a923-4284-b8f5-9e970477e9f2)

I'm not sure what would cause this; the container should size to fit its contents, and usually does.

This PR fixes this by explicitly setting the content area to `flex: 1`, so that it fills the area available to it, and doesn't attempt to shrink to its contents.

If more issues occur in the future, could look into the flexbox properties of the parent and ensure it lays out with flexbox as expected. But this did not seem necessary for the fix now.