### PR TITLE
Error out build if env var missing

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,4 +1,8 @@
-require('dotenv').config({path: './.env.production'});
+const dotenvResult = require('dotenv').config({path: './.env.production'});
+
+if (dotenvResult.error) {
+  throw dotenvResult.error;
+}
 
 const webpack = require('webpack');
 const {merge} = require('webpack-merge');


### PR DESCRIPTION
Prevents deploying to production with a broken Google Maps integration due to missing API key, especially if building on a new machine.