### PR TITLE
Stop reloading the whole board when a card is clicked

### DIFF
--- a/setupTests.js
+++ b/setupTests.js
@@ -1,1 +1,6 @@
 import '@testing-library/jest-dom';
+import {TextDecoder, TextEncoder} from 'node:util';
+
+// jsdom does not provide these, but react-router requires them
+global.TextEncoder ??= TextEncoder;
+global.TextDecoder ??= TextDecoder;

--- a/src/data/boards.js
+++ b/src/data/boards.js
@@ -16,7 +16,8 @@ function useBoardClient() {
   return boardClient;
 }
 
-const refreshBoards = queryClient => queryClient.invalidateQueries(['boards']);
+const refreshBoards = queryClient =>
+  queryClient.invalidateQueries({queryKey: ['boards']});
 
 export function useBoards() {
   const boardClient = useBoardClient();

--- a/src/data/cards.js
+++ b/src/data/cards.js
@@ -17,10 +17,10 @@ function useCardClient() {
 }
 
 const refreshCards = (queryClient, board) =>
-  queryClient.invalidateQueries(['cards', board.id]);
+  queryClient.invalidateQueries({queryKey: ['cards', board.id]});
 
 const refreshCard = (queryClient, board, card) =>
-  queryClient.invalidateQueries(['cards', board.id, card.id]);
+  queryClient.invalidateQueries({queryKey: ['cards', board.id, card.id]});
 
 const refreshAllColumnCards = queryClient =>
   queryClient.invalidateQueries({queryKey: ['columnCards']});
@@ -76,7 +76,7 @@ export function usePrimeCard({board}) {
 export function useForgetCard(board) {
   const queryClient = useQueryClient();
   return function forgetCard(card) {
-    queryClient.removeQueries(['cards', board.id, card.id]);
+    queryClient.removeQueries({queryKey: ['cards', board.id, card.id]});
   };
 }
 

--- a/src/data/cards.spec.js
+++ b/src/data/cards.spec.js
@@ -1,7 +1,7 @@
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {renderHook, waitFor} from '@testing-library/react';
 
-import {useColumnCards} from './cards';
+import {useColumnCards, useForgetCard, useRefreshCards} from './cards';
 
 jest.mock('./token', () => ({
   useToken: () => ({token: null}),
@@ -9,15 +9,20 @@ jest.mock('./token', () => ({
 
 jest.mock('../baseUrl', () => 'http://testapi');
 
-function makeWrapper() {
+function makeClientAndWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: {queries: {retry: false}},
   });
-  return function Wrapper({children}) {
+  function Wrapper({children}) {
     return (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
-  };
+  }
+  return {queryClient, wrapper: Wrapper};
+}
+
+function makeWrapper() {
+  return makeClientAndWrapper().wrapper;
 }
 
 describe('useColumnCards', () => {
@@ -109,5 +114,86 @@ describe('useColumnCards', () => {
 
     expect(resultA.current.data).toEqual(cardsA);
     expect(resultB.current.data).toEqual(cardsB);
+  });
+});
+
+describe('useForgetCard', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('does not reload the cards shown on the board', async () => {
+    const board = {id: '1', type: 'boards', attributes: {}};
+    const column = {id: '10', type: 'columns', attributes: {}};
+    const card = {id: '2', type: 'cards', attributes: {'field-values': {}}};
+
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({data: [card]}),
+    });
+
+    const {wrapper} = makeClientAndWrapper();
+    const {result, rerender} = renderHook(
+      () => ({
+        columnCards: useColumnCards(column),
+        forgetCard: useForgetCard(board),
+      }),
+      {wrapper},
+    );
+
+    await waitFor(() =>
+      expect(result.current.columnCards.isSuccess).toBe(true),
+    );
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    result.current.forgetCard(card);
+    rerender(); // clicking a card navigates, which rerenders the board
+
+    expect(result.current.columnCards.data).toEqual([card]);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes only the individual card query', () => {
+    const board = {id: '1', type: 'boards', attributes: {}};
+    const card = {id: '2', type: 'cards', attributes: {'field-values': {}}};
+
+    const {queryClient, wrapper} = makeClientAndWrapper();
+    queryClient.setQueryData(['cards', board.id, card.id], card);
+    queryClient.setQueryData(['columnCards', '10'], [card]);
+    queryClient.setQueryData(['cards', board.id], [card]);
+
+    const {result} = renderHook(() => useForgetCard(board), {wrapper});
+    result.current(card);
+
+    expect(
+      queryClient.getQueryData(['cards', board.id, card.id]),
+    ).toBeUndefined();
+    expect(queryClient.getQueryData(['columnCards', '10'])).toEqual([card]);
+    expect(queryClient.getQueryData(['cards', board.id])).toEqual([card]);
+  });
+});
+
+describe('useRefreshCards', () => {
+  it("invalidates only the board's card list", async () => {
+    const board = {id: '1', type: 'boards', attributes: {}};
+    const card = {id: '2', type: 'cards', attributes: {'field-values': {}}};
+
+    const {queryClient, wrapper} = makeClientAndWrapper();
+    queryClient.setQueryData(['cards', board.id], [card]);
+    queryClient.setQueryData(['columnCards', '10'], [card]);
+    queryClient.setQueryData(['boards'], [board]);
+
+    const {result} = renderHook(() => useRefreshCards(board), {wrapper});
+    await result.current();
+
+    const isStale = queryKey =>
+      queryClient.getQueryState(queryKey).isInvalidated;
+    expect(isStale(['cards', board.id])).toBe(true);
+    expect(isStale(['columnCards', '10'])).toBe(false);
+    expect(isStale(['boards'])).toBe(false);
   });
 });

--- a/src/data/columns.js
+++ b/src/data/columns.js
@@ -17,7 +17,7 @@ function useColumnClient() {
 }
 
 const refreshColumns = (queryClient, board) =>
-  queryClient.invalidateQueries(['columns', board.id]);
+  queryClient.invalidateQueries({queryKey: ['columns', board.id]});
 
 export function useColumns(board) {
   const columnClient = useColumnClient();

--- a/src/data/elements.js
+++ b/src/data/elements.js
@@ -17,7 +17,7 @@ function useElementClient() {
 }
 
 const refreshElements = (queryClient, board) =>
-  queryClient.invalidateQueries(['elements', board.id]);
+  queryClient.invalidateQueries({queryKey: ['elements', board.id]});
 
 export function useBoardElements(board) {
   const elementClient = useElementClient();

--- a/src/screens/Board/Board.js
+++ b/src/screens/Board/Board.js
@@ -1,5 +1,5 @@
 import {ThemeProvider as MuiProvider} from '@mui/material/styles';
-import {useCallback} from 'react';
+import {useCallback, useEffect} from 'react';
 import {Outlet, useNavigate, useParams} from 'react-router-dom';
 
 import ErrorSnackbar from '../../components/ErrorSnackbar';
@@ -104,14 +104,17 @@ export default function Board() {
     }
   })();
 
+  useEffect(() => {
+    if (board) {
+      document.title = board?.attributes?.name ?? '(unnamed board)';
+    }
+  }, [board]);
+
   useNavigateEffect(
     useCallback(() => {
-      if (board) {
-        document.title = board?.attributes?.name ?? '(unnamed board)';
-      }
       refreshCards();
       refreshColumnCards();
-    }, [board, refreshCards, refreshColumnCards]),
+    }, [refreshCards, refreshColumnCards]),
   );
 
   const colorTheme = useColorSchemeTheme(board?.attributes['color-theme']);

--- a/src/utils/useNavigateEffect.js
+++ b/src/utils/useNavigateEffect.js
@@ -1,8 +1,23 @@
 import {useEffect} from 'react';
-import {useLocation} from 'react-router-dom';
+import {useLocation, useResolvedPath} from 'react-router-dom';
 
+// Runs the callback when this screen's own route is the one being shown: on
+// first render, and each time the user navigates back to it. It does not run
+// when navigating to a child route (such as opening a card modal on top of the
+// board), because the user has not left this screen.
 export default function useNavigateEffect(callback) {
-  let location = useLocation();
+  const location = useLocation();
+  const routePath = useResolvedPath('.').pathname;
+  const isShowingThisRoute =
+    withoutTrailingSlash(location.pathname) === withoutTrailingSlash(routePath);
 
-  useEffect(() => callback({location}), [callback, location]);
+  useEffect(() => {
+    if (isShowingThisRoute) {
+      return callback({location});
+    }
+  }, [callback, isShowingThisRoute, location]);
+}
+
+function withoutTrailingSlash(path) {
+  return path.length > 1 ? path.replace(/\/$/, '') : path;
 }

--- a/src/utils/useNavigateEffect.spec.js
+++ b/src/utils/useNavigateEffect.spec.js
@@ -1,0 +1,64 @@
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {useCallback} from 'react';
+import {Link, MemoryRouter, Outlet, Route, Routes} from 'react-router-dom';
+
+import useNavigateEffect from './useNavigateEffect';
+
+function renderScreens(callback) {
+  function Parent() {
+    useNavigateEffect(useCallback(callback, [callback]));
+    return (
+      <div>
+        <Link to="/boards/1/cards/2">open child</Link>
+        <Outlet />
+      </div>
+    );
+  }
+
+  function Child() {
+    return <Link to="/boards/1">close child</Link>;
+  }
+
+  render(
+    <MemoryRouter initialEntries={['/boards/1']}>
+      <Routes>
+        <Route path="/boards/:boardId" element={<Parent />}>
+          <Route path="cards/:cardId" element={<Child />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('useNavigateEffect', () => {
+  it('runs the callback when the route is first shown', () => {
+    const callback = jest.fn();
+    renderScreens(callback);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not run the callback when navigating to a child route', async () => {
+    const user = userEvent.setup();
+    const callback = jest.fn();
+    renderScreens(callback);
+    callback.mockClear();
+
+    await user.click(screen.getByText('open child'));
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('runs the callback when navigating back from a child route', async () => {
+    const user = userEvent.setup();
+    const callback = jest.fn();
+    renderScreens(callback);
+
+    await user.click(screen.getByText('open child'));
+    callback.mockClear();
+    await user.click(screen.getByText('close child'));
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

Clicking a card on the board opens the card detail modal as intended, but it also reloads every card on the board.

## Causes

**1. `forgetCard` wiped the entire query cache.** `CardSummary` calls `forgetCard(card)` on click so the detail screen re-fetches instead of showing stale form data. That call used React Query v4 syntax:

```js
queryClient.removeQueries(['cards', board.id, card.id])
```

In v5 the first argument is a *filters object*. `matchQuery` destructures `queryKey` off the array, gets `undefined`, and skips key matching — so every query in the cache matched and was removed. The re-render triggered by the navigation then rebuilt those queries empty, flipping `ColumnList` to its loading state and re-fetching every column.

The same v4-ism was present in `refreshCards`, `refreshCard`, `refreshBoards`, `refreshColumns`, and `refreshElements`, each silently invalidating the whole cache on every mutation. All are converted to the v5 filters-object form.

**2. `useNavigateEffect` fired when navigating *away* to the modal.** The card modal is a child route of the board, so opening it counts as a location change and the board ran `refreshCards()` + `refreshColumnCards()` on the way in, not just on the way back. The hook now compares `useLocation().pathname` with `useResolvedPath('.')` and only runs when its own route is the leaf being shown. `document.title` moved into its own effect in `Board.js` so it is still set when a card URL is loaded directly.

## Testing

- New `src/utils/useNavigateEffect.spec.js`, plus `useForgetCard` / `useRefreshCards` tests in `src/data/cards.spec.js`. Verified they fail on `main` (`columnCards.data` becomes `undefined` after a click) and pass here.
- Full Jest suite passes; `pnpm lint` and `pnpm format:check` clean.
- Cypress suite passes: 9 specs, 31 passing, 1 pending, 0 failing.
- Manually verified in the browser against a local API, opening card 15 on a 3-column board:

  | | requests caused by one card click |
  | --- | --- |
  | before | `/boards/3` ×2, `/cards/15`, `/boards/3/elements`, `/boards/3/columns`, `/boards/3/cards`, **`/columns/5/cards`, `/columns/6/cards`, `/columns/7/cards`** |
  | after | `/cards/15` (plus `/boards/3` and `/boards/3/elements` when they are past `staleTime`) |

  Closing the modal still re-fetches `/boards/3/cards` and all three `/columns/*/cards`, so the intended refresh-when-you-return-to-the-board behavior is preserved.
- `setupTests.js` gains `TextEncoder`/`TextDecoder` polyfills, which react-router requires under jsdom.