### PR TITLE
Adopt the accessible field DOM structure in the date pickers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ coverage
 .env.production
 
 .playwright-mcp
+
+# Claude Code local state; shared config like .claude/settings.json stays tracked
+.claude/settings.local.json
+.claude/worktrees/

--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -1,0 +1,11 @@
+name: riverbed-weh
+root: .
+
+windows:
+  - main:
+      layout: main-vertical
+      panes:
+        - claude: claudeyolo
+        - server: pnpm start
+        # size columns equally, then leave shell available for future commands
+        - shell: tmux set-option -t main main-pane-width "50%" && tmux select-layout -t main main-vertical && clear

--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -1,4 +1,4 @@
-name: riverbed-weh
+name: riverbed-web
 root: .
 
 windows:

--- a/cypress/e2e/field-data-types.cy.js
+++ b/cypress/e2e/field-data-types.cy.js
@@ -122,35 +122,57 @@ describe('field data types', () => {
         .should('deep.include', {[choiceField.id]: 'fake_uuid_1'});
     });
 
-    // complex to manage desktop vs mobile version
-    // cy.step('TEST DATE FIELD', () => {
-    //   // button is not present in mobile date picker on CI
-    //   // cy.get(`[data-testid="element-${dateField.id}"] button`).click();
-    //   // cy.get('button').contains(/^2$/).click();
-    //   cy.get('[data-testid="date-input-2"]').type('01/02/2023');
-    //   cy.wait('@updateCard')
-    //     .its('request.body.data.attributes["field-values"]')
-    //     .should('deep.include', {[dateField.id]: '2023-01-02'});
-    // });
+    // The pickers render the accessible field DOM structure: instead of one
+    // <input>, each part of the date is a contenteditable span with
+    // role=spinbutton and an aria-label. Edit a single section so exactly one
+    // change is emitted.
 
-    // just skip it: typing and pasting both have issues in Cypress
-    // cy.step('TEST DATETIME FIELD', () => {
-    //   // button is not present in mobile date picker on CI
-    //   // cy.get(`[data-testid=element-${dateTimeField.id}] button`).click();
-    //   // cy.get('button').contains(/^3$/).click();
-    //   // cy.get('[role=option]').contains(/^05$/).click();
-    //   // cy.get('[role=option]').contains(/^15$/).click();
-    //   // cy.get('[role=option]').contains(/^PM$/).click();
-    //   // cy.contains('OK').click();
-    //   cy.get('[data-testid="datetime-input-3"] input').focus();
-    //   // paste
-    //   cy.get('[data-testid="datetime-input-3"] input').invoke(
-    //     'val',
-    //     '01/02/2023 04:56 PM',
-    //   );
-    //   cy.get('[data-testid="datetime-input-3"] input').blur();
-    //   cy.wait('@updateCard'); // not verifying contents due to time zone issues
-    // });
+    cy.step('TEST DATE FIELD', () => {
+      cy.get(`[data-testid="date-input-${dateField.id}"]`)
+        .find('[aria-label="Day"]')
+        .click()
+        .type('2');
+      cy.wait('@updateCard')
+        .its('request.body.data.attributes["field-values"]')
+        .should('deep.include', {[dateField.id]: '2023-01-02'});
+    });
+
+    cy.step('TEST DATE FIELD KEYBOARD NAVIGATION', () => {
+      const dateInput = () =>
+        cy.get(`[data-testid="date-input-${dateField.id}"]`);
+
+      // arrow keys move focus between sections and step the focused section's
+      // value; that section model is the point of the accessible DOM structure
+      dateInput().find('[aria-label="Month"]').click().type('{rightArrow}');
+      dateInput().find('[aria-label="Day"]').should('be.focused');
+      dateInput().find('[aria-label="Day"]').type('{rightArrow}');
+      dateInput().find('[aria-label="Year"]').should('be.focused');
+
+      dateInput().find('[aria-label="Year"]').type('{upArrow}');
+      // only the year is asserted: it steps 2023 -> 2024 regardless of which
+      // day the step above left behind
+      cy.wait('@updateCard')
+        .its(`request.body.data.attributes["field-values"][${dateField.id}]`)
+        .should('match', /^2024-/);
+    });
+
+    cy.step('TEST DATETIME FIELD', () => {
+      cy.get(`[data-testid="datetime-input-${dateTimeField.id}"]`)
+        .find('[aria-label="Minutes"]')
+        .click()
+        .type('45');
+      // asserted through a local Date rather than a literal string: the value
+      // is sent as UTC, so the expected string differs per time zone
+      cy.wait('@updateCard')
+        .its(
+          `request.body.data.attributes["field-values"][${dateTimeField.id}]`,
+        )
+        .then(value => {
+          const sent = new Date(value);
+          expect(sent.getHours()).to.equal(13);
+          expect(sent.getMinutes()).to.equal(45);
+        });
+    });
 
     cy.step('TEST GEOLCOATION FIELD', () => {
       cy.get(

--- a/docs/mui-upgrade-plan.md
+++ b/docs/mui-upgrade-plan.md
@@ -45,29 +45,45 @@ Notes from this stage:
   back out via `enableAccessibleFieldDOMStructure={false}` to keep markup and
   `data-testid` placement unchanged. See Stage 2.
 
-## Stage 2 — adopt the accessible field DOM structure
+## Stage 2 — adopt the accessible field DOM structure (complete)
 
-**Do this as its own PR, before Stage 3.** It is a behavioral change to the date
-pickers, not a version bump, and it should not be entangled with one.
+Done as its own PR, before Stage 3: a behavioral change to the date pickers
+rather than a version bump, so it was kept out of one. The opt-out added in
+Stage 1 pinned deprecated v7 behavior, and the flag is removed outright in
+pickers v9 — carrying it further would have turned that bump into a forced UI
+change.
 
-The opt-out added in Stage 1 pins deprecated v7 behavior. Carrying it into a
-further major risks the flag being removed while the migration is still
-outstanding, which would turn a version bump into a forced UI change.
+Work done:
 
-Work involved:
-
-- Remove `enableAccessibleFieldDOMStructure={false}` from
+- Removed `enableAccessibleFieldDOMStructure={false}` from
   `src/components/fieldTypes/lazy/DateEditorComponent.js` and
   `src/components/fieldTypes/lazy/DateTimeEditorComponent.js`.
-- Move the `data-testid` off the deprecated `slotProps.textField.inputProps` and
-  onto `slotProps.htmlInput` or the field root, since there is no longer a
-  single `<input>` to hang it on.
-- Re-enable and rewrite the date-editing assertions in
-  `cypress/e2e/field-data-types.cy.js`, which are currently commented out. They
-  type into the picker input directly and will need to drive the sectioned
-  field instead.
-- Manually check keyboard navigation across the date sections, since the section
-  model is what the new structure exists to provide.
+- Moved the date editor's `data-testid` from `slotProps.textField.inputProps`
+  onto the field root, matching what the datetime editor already did. Not
+  `slotProps.htmlInput`: under the new structure that lands on the *visually
+  hidden* input kept only for form interop, which tests cannot drive.
+- Re-enabled and rewrote the date-editing assertions in
+  `cypress/e2e/field-data-types.cy.js`, plus a keyboard-navigation step.
+- Rewrote the three `DateEditorComponent.spec.js` tests that queried
+  `role="textbox"`, which no longer exists.
+
+Notes from this stage:
+
+- The rendered field is a `role="group"` wrapping one
+  `span[role="spinbutton"][contenteditable]` per section, labelled `Month`,
+  `Day`, `Year` (plus `Hours`, `Minutes`, `Meridiem` for datetime). Select
+  sections by `aria-label`; there is no input to type into.
+- Edit **one section at a time** in tests. Typing a full date walks through
+  several intermediate valid dates and emits a PATCH for each, so a single
+  `cy.wait('@updateCard')` would assert against the wrong one.
+- Clearing is `ctrl+A` then `Delete` — `user.clear()` needs an input.
+- The datetime value is sent as UTC, so assert through a local `Date` rather
+  than a literal string, or the test only passes in one time zone.
+- The old "mobile picker on CI" problem did not reappear: under
+  `--browser chrome`, which is what CI uses, the desktop variant renders and
+  its sections are editable. Worth re-checking if these tests ever fail only on
+  CI, since the mobile field is read-only and typing into it silently does
+  nothing.
 
 ## Stage 3 — Material 7 → 9, pickers 8 → 9
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
   "jest": {
     "testEnvironment": "jsdom",
     "modulePathIgnorePatterns": [
-      "cypress"
+      "cypress",
+      "<rootDir>/.claude"
     ],
     "setupFilesAfterEnv": [
       "./setupTests.js"

--- a/src/components/fieldTypes/lazy/DateEditorComponent.js
+++ b/src/components/fieldTypes/lazy/DateEditorComponent.js
@@ -18,16 +18,14 @@ function DateEditorComponent({field, label, value, setValue, disabled, style}) {
           }
         }}
         disabled={disabled}
-        // TODO: remove before upgrading to x-date-pickers v9; the accessible
-        // field DOM structure is the v8 default and this opts back out of it.
-        enableAccessibleFieldDOMStructure={false}
         slotProps={{
           textField: {
             variant: 'filled',
             style,
-            inputProps: {
-              'data-testid': `date-input-${field.id}`,
-            },
+            // on the field root, not the input: the accessible field DOM
+            // structure renders the editable sections as spans and keeps only
+            // a visually hidden input for form interop.
+            'data-testid': `date-input-${field.id}`,
           },
         }}
       />

--- a/src/components/fieldTypes/lazy/DateEditorComponent.spec.js
+++ b/src/components/fieldTypes/lazy/DateEditorComponent.spec.js
@@ -38,7 +38,10 @@ describe('DateEditorComponent', () => {
       />,
     );
 
-    await user.type(screen.getByRole('textbox', {name: label}), '10/31/2023');
+    // the accessible field DOM structure has no single <input>: each part of
+    // the date is a spinbutton, and typing advances to the next one
+    await user.click(screen.getByRole('spinbutton', {name: 'Month'}));
+    await user.keyboard('10312023');
 
     expect(setValue).toHaveBeenCalledWith('2023-10-31');
   });
@@ -54,8 +57,9 @@ describe('DateEditorComponent', () => {
       />,
     );
 
-    // simulates a partially-entered date
-    await user.type(screen.getByRole('textbox', {name: label}), '1');
+    // simulates a partially-entered date: month only, no day or year
+    await user.click(screen.getByRole('spinbutton', {name: 'Month'}));
+    await user.keyboard('1');
 
     expect(setValue).not.toHaveBeenCalled();
   });
@@ -71,7 +75,9 @@ describe('DateEditorComponent', () => {
       />,
     );
 
-    await user.clear(screen.getByRole('textbox'));
+    // ctrl+A selects every section, so Delete empties the whole field
+    await user.click(screen.getByRole('spinbutton', {name: 'Month'}));
+    await user.keyboard('{Control>}a{/Control}{Delete}');
 
     expect(setValue).toHaveBeenCalledWith(null);
   });

--- a/src/components/fieldTypes/lazy/DateTimeEditorComponent.js
+++ b/src/components/fieldTypes/lazy/DateTimeEditorComponent.js
@@ -23,9 +23,6 @@ function DateTimeEditorComponent({
           setValue(string);
         }}
         disabled={disabled}
-        // TODO: remove before upgrading to x-date-pickers v9; the accessible
-        // field DOM structure is the v8 default and this opts back out of it.
-        enableAccessibleFieldDOMStructure={false}
         slotProps={{
           textField: {
             style,


### PR DESCRIPTION
Stage 2 of the MUI upgrade plan. Removes the `enableAccessibleFieldDOMStructure={false}` opt-out added in Stage 1, so the date and datetime pickers use the v8 default field structure.

The opt-out pinned deprecated v7 behavior, and the flag is removed outright in pickers v9 — carrying it further would have turned that bump into a forced UI change. Doing it as its own PR keeps a behavioral change to the pickers separate from a version bump.

## What changed

- Removed `enableAccessibleFieldDOMStructure={false}` from `DateEditorComponent` and `DateTimeEditorComponent`.
- Moved the date editor's `data-testid` from `slotProps.textField.inputProps` onto the field root, matching what the datetime editor already did. Not `slotProps.htmlInput`: under the new structure that lands on the visually hidden input kept only for form interop, which tests cannot drive.
- Re-enabled and rewrote the date and datetime assertions in `cypress/e2e/field-data-types.cy.js`, which had been commented out, and added a keyboard-navigation step.
- Rewrote the three `DateEditorComponent.spec.js` tests that queried `role="textbox"`, which no longer exists.
- Updated `docs/mui-upgrade-plan.md` with what Stage 2 actually involved.

## The new structure

The field renders as a `role="group"` wrapping one `span[role="spinbutton"][contenteditable]` per section, labelled `Month`, `Day`, `Year` (plus `Hours`, `Minutes`, `Meridiem` for datetime). There is no longer a single `<input>` to type into — select sections by `aria-label`.

Tests should edit one section at a time. Typing a full date into an already-populated field walks through several intermediate valid dates and emits a PATCH for each, so a single `cy.wait('@updateCard')` would assert against the wrong one.

## Verification

Driven manually in a browser against a local API, checking the actual PATCH payload at each step:

| Interaction | Payload |
| --- | --- |
| Type `2` into Day | `"2023-01-02"` |
| ArrowRight from Month, twice | focus moves Month → Day → Year |
| ArrowUp on Year | `"2024-01-02"` |
| Type `45` into datetime Minutes | `...T12:45:56Z`, hours preserved |
| Calendar popup → 15 | `"2024-01-15"` |
| Ctrl+A, Delete | `null` |
| Retype a full date into an empty field | one PATCH, `"2023-01-05"` |

Keyboard navigation across sections was checked specifically, since the section model is what the new structure exists to provide. Partial dates emit nothing, and single-section edits emit exactly one change — which the rewritten Cypress steps depend on.

`pnpm test:ci` (407 passing), `pnpm cypress:run --spec cypress/e2e/field-data-types.cy.js`, `pnpm lint`, and `pnpm format:check` all pass.

## Also included

Two commits of unrelated local tooling that were already on this branch:

- `.tmuxinator.yml` for a dev tmux session.
- Keeping Claude Code's agent worktrees (`.claude/worktrees/`) out of the jest run and out of git. Jest was walking into the duplicated spec files there and making `pnpm test:ci` exit 1 despite no real failures. The ignore pattern is anchored with `<rootDir>` deliberately: these match the full absolute path, so a bare `.claude` would also match a worktree's own files and leave tests run from inside a worktree finding nothing.

Happy to split either of these out if you'd rather they not ride along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)